### PR TITLE
S3Role - Lambda as a Principal and DynamoDB perm

### DIFF
--- a/MonoToMicroAssets/MonoToMicroCF.template
+++ b/MonoToMicroAssets/MonoToMicroCF.template
@@ -252,6 +252,24 @@
 				}]
 			}
 		},
+		"LambdaPolicy": {
+			"Type": "AWS::IAM::Policy",
+			"Properties": {
+				"PolicyName": "DynamoDBPermissions",
+				"PolicyDocument": {
+					"Statement": [{
+						"Effect": "Allow",
+						"Action": [
+							"dynamodb:*"
+						],
+						"Resource": "*"
+					}]
+				},
+				"Roles": [{
+					"Ref": "S3Role"
+				}]
+			}
+		},
 		"S3Role": {
 			"Type": "AWS::IAM::Role",
 			"Properties": {
@@ -260,7 +278,7 @@
 					"Statement": [{
 						"Effect": "Allow",
 						"Principal": {
-							"Service": ["ec2.amazonaws.com"]
+							"Service": ["ec2.amazonaws.com", "lambda.amazonaws.com" ]
 						},
 						"Action": [
 							"sts:AssumeRole"


### PR DESCRIPTION
S3Role is used in the workshop in MonoToMicroLambda lab, however (1) Lambda is not a Principal, (2) There is no policy to give the Lambda function access to  DynamoDB, (3) There is no step in the instructions to guide one into fixing these pieces. 

So: 
(1) I have added the LambdaPolicy to the role, giving full access to DynamoDB (maybe we should constrain that; or move that to instructions into the READ.mes
(2) I have added lambda.amazonaws.com as a Principal on S3Role